### PR TITLE
Split out common.translate module

### DIFF
--- a/mocks/common-mock.js
+++ b/mocks/common-mock.js
@@ -4,17 +4,17 @@ var i18n = {
   }
 };
 
-angular.module('risevision.widget.common', [], function() {
+angular.module("risevision.widget.common", ["risevision.widget.common.translate"]);
 
-})
-// mock the translate filter
-  .filter('translate', function () {
-    return function (val) {
-      return val;
-    };
-  })
-  .service('i18nLoader', [function () {
+angular.module("risevision.widget.common.translate", [])
+  .service("i18nLoader", function () {
     this.get = function () {
       return { then: function(cb) { cb(); }};
     };
-  }]);
+  })
+  // mock the translate filter
+  .filter("translate", function () {
+    return function (val) {
+      return val;
+    };
+  });


### PR DESCRIPTION
Updated as per common.js from widget-settings-ui-components. Will remove that file and reference this going forward. 

@stulees @donnapep please review. Thanks.
