### PR TITLE
[Fix] Allowing for more than just gadget-mocks in htmlE2E task

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,9 +43,13 @@
       },
       htmlE2E: function (options) {
         options = options || {};
+        if (!options.hasOwnProperty("e2egadgets")) {
+          options.e2egadgets = "../node_modules/widget-tester/gadget-mocks.js";
+        }
+
         return function () {
           return gulp.src("./src/settings.html")
-            .pipe(htmlreplace({e2egadgets: "../node_modules/widget-tester/gadget-mocks.js" }))
+            .pipe(htmlreplace(options))
             .pipe(rename(function (path) {
               path.basename += "-e2e";
             }))


### PR DESCRIPTION
- Using the options param in the htmlreplace() method so that other mocks can be defined in options
- Maintaining e2egadgets as one to always be included
