### PR TITLE
[Fix] Allowing for unit tests involving google picker service

### DIFF
--- a/mocks/gapi-picker-mock.js
+++ b/mocks/gapi-picker-mock.js
@@ -1,4 +1,4 @@
-(function (window, handleClientJSLoad){
+(function (window){
   "use strict";
 
   /* global handleClientJSLoad:false */
@@ -314,6 +314,11 @@
     window._pickerCallbackFn.call(null, req);
   };
 
-  handleClientJSLoad();
+  if (typeof window.isClientJS === "undefined") {
+    window.isClientJS = true;
+  }
+  else {
+    window.handleClientJSLoad();
+  }
 
-})(window, handleClientJSLoad);
+})(window);


### PR DESCRIPTION
- Checking for isClientJS exists on window instead of passing global reference of handleClientJSLoad function
- This fix stops an error occurring during unit tests as handleClientJSLoad is not defined
