### PR TITLE
added files property to html:E2E task

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,9 +59,12 @@
         if (!options.hasOwnProperty("e2egadgets")) {
           options.e2egadgets = "../node_modules/widget-tester/gadget-mocks.js";
         }
+        if (!options.hasOwnProperty("files")) {
+          options.files = "./src/settings.html";
+        }
 
         return function () {
-          return gulp.src("./src/settings.html")
+          return gulp.src(options.files)
             .pipe(htmlreplace(options))
             .pipe(rename(function (path) {
               path.basename += "-e2e";


### PR DESCRIPTION
- htmle2e sources the provided list of files to inject gadgets mock into
- if files option is not present, default to './src/settings.html' as before

could @settinghead review + merge?
