### PR TITLE
[fix] Added common-i18n mock

### DIFF
--- a/mocks/common-mock.js
+++ b/mocks/common-mock.js
@@ -4,22 +4,11 @@ var i18n = {
   }
 };
 
-angular.module("risevision.widget.common", ["risevision.widget.common.translate"]);
-
-angular.module("risevision.widget.common.translate", [])
+angular.module("risevision.widget.common", [])
   .service("i18nLoader", function () {
     this.get = function () {
       return { then: function(cb) { cb(); }};
     };
-  })
-  // mock the translate filter
-  .filter("translate", function () {
-    return function (val) {
-      return val;
-    };
   });
 
-angular.module('risevision.common.i18n.config', [])
-  .constant('LOCALES_PREFIX',
-    '/components/rv-common-i18n/dist/locales/translation_')
-  .constant('LOCALES_SUFIX', '.json');
+angular.module('risevision.common.i18n', []);


### PR DESCRIPTION
Added mock for `risevision.common.i18n`

Removed `risevision.widget.common.translate` mock

The `i18nLoader` service actually belongs to `risevision.widget.common` - https://github.com/Rise-Vision/widget-settings-ui-core/blob/master/src/js/svc-i18n-legacy.js.

@donnapep and/or @stulees please review. Thanks!