### PR TITLE
[fix] Added i18n.config mock

### DIFF
--- a/mocks/i18n-config.js
+++ b/mocks/i18n-config.js
@@ -10,10 +10,8 @@ angular.module("risevision.widget.common", [])
       return { then: function(cb) { cb(); }};
     };
   });
-
-angular.module('risevision.common.i18n', [])
-  .filter("translate", function () {
-    return function (val) {
-      return val;
-    };
-  });
+  
+angular.module('risevision.common.i18n.config', [])
+  .constant('LOCALES_PREFIX',
+    '/components/rv-common-i18n/dist/locales/translation_')
+  .constant('LOCALES_SUFIX', '.json');


### PR DESCRIPTION
i18n.config
- should be used for e2e tests to provide location of the translation files
- it also provides risevision.widget.common mock

widget-common
- also added mock for the translate filter