### PR TITLE
fix sinon version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "properties": "^1.2.1",
     "reporter-file": "0.0.1",
     "run-sequence": "^0.3.6",
-    "sinon": "^1.11.1",
+    "sinon": "1.14.1",
     "sinon-chai": "^2.6.0",
     "spawn-cmd": "0.0.2",
     "xml2js": "^0.4.4",


### PR DESCRIPTION
@olegrise @rodrigopavezi looks like the latest version is missing a `pkg` folder (https://github.com/cjohansen/Sinon.JS/issues/761). Tests are failing because of this.

Temporarily lock down version until fixed. Please review. Thanks.