### PR TITLE
Fix/e2e test reporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,10 +176,10 @@
             }))
             .on("error", function (e) {
               gutil.log(e);
-              if(fs.statSync("./reports/angular-xunit.xml")) {
+              /*if(fs.statSync("./reports/angular-xunit.xml")) {
                 //output test result to console
                 gutil.log("Test report", fs.readFileSync("./reports/angular-xunit.xml", {encoding: "utf8"}));
-              }
+              }*/
               if(options.throw || options.throw ===undefined) {
                 throw e;
               }

--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
     "karma-chai-plugins": "^0.2.1",
     "karma-coverage": "^0.2.4",
     "karma-junit-reporter": "^0.2.2",
-    "karma-mocha": "^0.1.6",
+    "karma-mocha": "^0.2.0",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-sinon-chai": "^0.2.0",
     "lodash": "^2.4.1",
-    "mocha": "^1.20.1",
+    "mocha": "^2.3.3",
     "node-uuid": "^1.4.1",
     "properties": "^1.2.1",
     "reporter-file": "0.0.1",
@@ -55,6 +55,9 @@
     "spawn-cmd": "0.0.2",
     "xml2js": "^0.4.4",
     "xunit-file": "0.0.5",
-    "yargs": "^1.3.1"
+    "yargs": "^1.3.1",
+    "spec-xunit-file": "0.0.1-3",
+    "mocha-multi": "0.7.2",
+    "mocha-proshot": "1.0.1"
   }
 }

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -3,7 +3,9 @@ if(process.env.SELENIUM_ADDRESS) {
   seleniumAddress = process.env.SELENIUM_ADDRESS;
 }
 process.env.LOG_XUNIT = true;
-process.env.XUNIT_FILE = 'reports/angular-xunit.xml';
+process.env.XUNIT_FILE = (typeof process.env.XUNIT_FILE === 'undefined'  || process.env.XUNIT_FILE === '') ? 'reports/angular-xunit.xml': process.env.XUNIT_FILE;
+process.env.PROSHOT_DIR = (typeof process.env.PROSHOT_DIR === 'undefined'  || process.env.PROSHOT_DIR === '') ? 'reports/screenshots': process.env.PROSHOT_DIR;
+process.env.multi = 'spec-xunit-file=- mocha-proshot=-';
 process.env.CHROME_INSTANCES = process.env.CHROME_INSTANCES || 1;
 // process.env.MOCHA_REPORTER_FILE = 'reports/anglar.json';
 // process.env.MOCHA_REPORTER = 'JSON';
@@ -34,7 +36,7 @@ exports.config = {
 
   mochaOpts: {
     // reporter: 'require("xunit-file")',
-    reporter: 'spec',
+    reporter: 'mocha-multi',
     enableTimeouts: false,
     slow: 3000
   }


### PR DESCRIPTION
@alex-deaconu I had to update mocha libs versions so the new report could work. Please review. 

You can see an example of a build with it here https://circleci.com/gh/Rise-Vision/schedules-app/289
Note the screenshot of the failure test on the Artifacts tab. 

It is still not augmenting each spec xunit output into one file it rewrites the file for each spec. I remember you had a look at this issue before. Would you know how we could fix that?

@ezequielc FYI. 

cheers