### PR TITLE
Increase protractor timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-tester",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "Configuration, task & mocks related to widget testing.",
   "main": "index.js",
   "scripts": {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -12,7 +12,7 @@ process.env.CHROME_INSTANCES = process.env.CHROME_INSTANCES || 1;
 
 exports.config = {
   directConnect: true,
-  allScriptsTimeout: 11000,
+  allScriptsTimeout: 30000,
 
   // specs: [
   //   './test/e2e/angular/*.js'


### PR DESCRIPTION
Recommended solution (https://github.com/angular/protractor/blob/master/docs/timeouts.md#waiting-for-angular); should fix some of these failures for Apps e2e tests:
<img width="1011" alt="screen shot 2017-11-01 at 1 18 48 pm" src="https://user-images.githubusercontent.com/6218188/32287450-4575810a-bf07-11e7-8596-1ddb19045f01.png">

@fjvallarino please review. Thanks!