### PR TITLE
 Provide stage environment name to e2e tests

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-tester",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "homepage": "https://github.com/Rise-Vision/widget-tester",
   "authors": [
     "Xiyang Chen <settinghead@gmail.com>"

--- a/index.js
+++ b/index.js
@@ -201,8 +201,8 @@
           var args = ["--baseUrl", options.baseUrl || "http://" + require("./getIpAddress")() + ":" + e2ePort + "/src/settings-e2e.html",
             "--params.login.user", options.loginUser, "--params.login.pass", options.loginPass,
             "--params.login.user2", options.loginUser2, "--params.login.pass2", options.loginPass2,
-            "--params.login.stageEnv", options.stageEnv, "--params.login.stageUser", options.stageUser,
-            "--params.twitter.user", options.twitterUser, "--params.twitter.pass", options.twitterPass];
+            "--params.twitter.user", options.twitterUser, "--params.twitter.pass", options.twitterPass,
+            "--params.login.stageEnv", options.stageEnv];
           var argv = require("yargs").argv;
           if(!options.specs && argv.specs) {
             options.specs = argv.specs;

--- a/index.js
+++ b/index.js
@@ -201,6 +201,7 @@
           var args = ["--baseUrl", options.baseUrl || "http://" + require("./getIpAddress")() + ":" + e2ePort + "/src/settings-e2e.html",
             "--params.login.user", options.loginUser, "--params.login.pass", options.loginPass,
             "--params.login.user2", options.loginUser2, "--params.login.pass2", options.loginPass2,
+            "--params.login.stageEnv", options.stageEnv, "--params.login.stageUser", options.stageUser,
             "--params.twitter.user", options.twitterUser, "--params.twitter.pass", options.twitterPass];
           var argv = require("yargs").argv;
           if(!options.specs && argv.specs) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-tester",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Configuration, task & mocks related to widget testing.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This change is needed to provide the environment name (STAGE_ENV in CircleCI) to the Protractor test logic.

@santiagonoguez @stulees @Rise-Vision/apps please review