### PR TITLE
Use full path for downloads folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-tester",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Configuration, task & mocks related to widget testing.",
   "main": "index.js",
   "scripts": {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -36,7 +36,7 @@ exports.config = {
     },
     chromeOptions: {
       prefs: {
-        'download.default_directory':'./tmp'
+        'download.default_directory': process.cwd() + '/tmp'
       }
     }
   },


### PR DESCRIPTION
Based on the change introduced with Chrome 75 ([change log entry](https://chromium.googlesource.com/chromium/src/+/91a68446754ca44b7ea0b2acd765924d626b9ffa)), download locations can no longer use a relative path.

Fixes Apps build: https://circleci.com/gh/Rise-Vision/rise-vision-apps/26026

@ezequielc @fjvallarino please review. Thanks!