### PR TITLE
Remove segment mock, moved to Apps

### DIFF
--- a/mocks/segment-analytics-mock.js
+++ b/mocks/segment-analytics-mock.js
@@ -1,9 +1,0 @@
-(function (angular) {
-
-  "use strict";
-
-  // This mock disables the segment.io tracking script by
-  // resetting the API key
-  angular.module("risevision.common.components.analytics")
-    .value("SEGMENT_API_KEY", null);
-})(angular);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-tester",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Configuration, task & mocks related to widget testing.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Description
Remove segment mock, moved to Apps

## Motivation and Context
Mock is now moved to Apps as per https://github.com/Rise-Vision/rise-vision-apps/pull/1486

## How Has This Been Tested?
Apps unit tests pass.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No