### PR TITLE
Add mock for heartbeat start

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-tester",
-  "version": "1.9.1",
+  "version": "1.13.0",
   "homepage": "https://github.com/Rise-Vision/widget-tester",
   "authors": [
     "Xiyang Chen <settinghead@gmail.com>"

--- a/mocks/logger-mock.js
+++ b/mocks/logger-mock.js
@@ -86,6 +86,8 @@
     },
     setVersion: function(value) {
       version = value;
+    },
+    startEndpointHeartbeats: function() {
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-tester",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Configuration, task & mocks related to widget testing.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Description
Mock the logger's startEndpointHeartbeats function for testing.

## Motivation and Context
Added as part of [PR 167](https://github.com/Rise-Vision/widget-common/pull/167), the function should be included in the mocks here.

## How Has This Been Tested?
As part of image widget upcoming PR.
