### PR TITLE
Add a check for native angular notify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-tester",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Configuration, task & mocks related to widget testing.",
   "main": "index.js",
   "scripts": {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -53,14 +53,34 @@ exports.config = {
     },
     enableTimeouts: false,
     slow: 3000
-  }
+  },
+  onPrepare: function() {
+    var ignoreScript = "var callback = arguments[arguments.length - 1];" +
+        "callback()";
+    var script = "var callback = arguments[arguments.length - 1];" +
+        "angular.element(document.querySelector(\"body\")).injector()"+
+        ".get(\"$browser\").notifyWhenNoOutstandingRequests(callback)";
 
-  // onPrepare: function() {
-  //   // The require statement must be down here, since jasmine-reporters
-  //   // needs jasmine to be in the global and protractor does not guarantee
-  //   // this until inside the onPrepare function.
-  //   require("jasmine-reporters");
-  //   jasmine.getEnv().addReporter(
-  //     new jasmine.JUnitXmlReporter('xmloutput', true, true));
-  // }
+    browser.waitForAngular = function() {
+      if (browser.ignoreSynchronization) {
+        return browser.executeAsyncScript(ignoreScript);
+      }
+
+      return browser.wait(function () {
+        return browser.executeScript('return !!window.angular && !!angular.element(document.querySelector(\"body\")).injector()');
+      }, 10000)
+        .then(function() {
+          return browser.executeAsyncScript(script);
+        }); // 10000 is the timeout in millis
+    };
+
+    var getUrl = "var callback = arguments[arguments.length - 1];" +
+        "callback(window.location.href)";
+
+    browser.getCurrentUrl = function() {
+      return browser.executeAsyncScript(getUrl);
+    };
+
+
+  }
 };


### PR DESCRIPTION
## Description
Add a check for native angular notify

Skip check if synchronization is ignored
Wait for angular to be present

Mock getCurrentUrl as well

## Motivation and Context
Fix angular2 e2e tests

## How Has This Been Tested?
Apps build passes.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No