### PR TITLE
Use src folder for coverage reporting

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,7 +10,7 @@ module.exports = function(config){
     browsers : ["ChromeHeadless"],
 
     preprocessors : {
-      "web/script/**/*.js": "coverage"
+      "src/script/**/*.js": "coverage"
     },
 
     reporters: ["progress", "junit", "coverage"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-tester",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-tester",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Configuration, task & mocks related to widget testing.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Description
Use src folder for coverage reporting

## Motivation and Context
Updated folder structure in Apps

## How Has This Been Tested?
Coverage reporting works as expected.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No